### PR TITLE
fix: update libudev-dev version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -123,7 +123,7 @@ RUN set -x \
     python-is-python3=3.8.2-4 \
 ##  Ledger Live build dependecies.
     libqt5websockets5-dev=5.12.8-0ubuntu1 \
-    libudev-dev=245.4-4ubuntu3.11 \
+    libudev-dev=245.4-4ubuntu3.13 \
     libusb-1.0-0-dev=2:1.0.23-2build1 \
     qtbase5-dev=5.12.8+dfsg-0ubuntu1 \
 ##  Convenience utils specific to this Docker environment.


### PR DESCRIPTION
[`systemd`], the dependency for [`libudev-dev`], has been [updated again][changelog].

[`systemd`]: https://packages.ubuntu.com/focal-updates/systemd
    (Ubuntu – Details of source package systemd in focal-updates)
[`libudev-dev`]: https://packages.ubuntu.com/focal-updates/libudev-dev
    (Ubuntu – Details of package libudev-dev in focal-updates)
[changelog]: https://changelogs.ubuntu.com/changelogs/pool/main/s/systemd/systemd_245.4-4ubuntu3.13/changelog